### PR TITLE
Use non-privileged port number

### DIFF
--- a/py_impactjs.py
+++ b/py_impactjs.py
@@ -166,4 +166,4 @@ def send_game_file(game, *pathparts):
 
 # Run dev server
 if __name__ == '__main__':
-    app.run('localhost', port = 80, debug = True)
+    app.run('localhost', port = 8080, debug = True)


### PR DESCRIPTION
Use a higher port number to allow running server without `sudo`. You can't bind to port numbers lower than 1024 as an unprivileged user.